### PR TITLE
Розширення очищення для Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,6 @@ cleaner.cmd
 
 В обох випадках викликається Node.js-скрипт `cleaner.js`, який видаляє вміст стандартних тимчасових директорій (наприклад, `/tmp` у Linux та `%TEMP%` у Windows).
 
+Починаючи з версії 1.1 скрипт під Linux також очищає каталоги `/var/tmp`, `/var/cache/apt/archives` та `~/.cache` при їх наявності.
+
 Скрипти автоматично перевіряють наявність Node.js і за потреби встановлюють його. Під Windows додатково очищаються системні каталоги `Prefetch`, `SoftwareDistribution\\Download` та `System32\\LogFiles`.

--- a/cleaner.js
+++ b/cleaner.js
@@ -3,6 +3,12 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
+function pushIfExists(list, dir) {
+  if (fs.existsSync(dir)) {
+    list.push(dir);
+  }
+}
+
 async function removeDirContents(dir) {
   try {
     const entries = await fs.promises.readdir(dir);
@@ -17,18 +23,22 @@ async function removeDirContents(dir) {
 }
 
 async function clean() {
-  const targets = [os.tmpdir()];
+  const targets = [];
+  pushIfExists(targets, os.tmpdir());
   if (process.platform === 'win32') {
     const winDir = process.env.WINDIR || 'C:/Windows';
-    targets.push(path.join(winDir, 'Temp'));
-    targets.push(path.join(winDir, 'Prefetch'));
-    targets.push(path.join(winDir, 'SoftwareDistribution', 'Download'));
-    targets.push(path.join(winDir, 'System32', 'LogFiles'));
+    pushIfExists(targets, path.join(winDir, 'Temp'));
+    pushIfExists(targets, path.join(winDir, 'Prefetch'));
+    pushIfExists(targets, path.join(winDir, 'SoftwareDistribution', 'Download'));
+    pushIfExists(targets, path.join(winDir, 'System32', 'LogFiles'));
     if (process.env.SystemDrive) {
-      targets.push(path.join(process.env.SystemDrive, 'Temp'));
+      pushIfExists(targets, path.join(process.env.SystemDrive, 'Temp'));
     }
   } else {
-    targets.push('/var/tmp');
+    pushIfExists(targets, '/var/tmp');
+    pushIfExists(targets, '/var/cache/apt/archives');
+    pushIfExists(targets, '/var/cache/apt/archives/partial');
+    pushIfExists(targets, path.join(os.homedir(), '.cache'));
   }
   for (const dir of targets) {
     await removeDirContents(dir);


### PR DESCRIPTION
## Зміни
- скрипт `cleaner.js` тепер перевіряє існування каталогів перед додаванням у список
- додано очищення `/var/cache/apt/archives`, `/var/cache/apt/archives/partial` та `~/.cache`
- README оновлено з описом нових можливостей

## Тести
- `node cleaner.js`

------
https://chatgpt.com/codex/tasks/task_e_688a220a0268832ea3281d6f78a1c537