### PR TITLE
Додано веб-інтерфейс для ts-dustbuster

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,13 @@ The `cleaner.js` script supports several command-line options:
 - `--config <file>` — JSON file with a `dirs` array of paths.
 - `--log <файл>` — зберігати інформацію про виконання у вказаний файл.
 - `--log <file>` — store execution information in the specified file.
+
+### Графічний режим
+
+Для запуску простого веб‑інтерфейсу виконайте:
+
+```bash
+node gui.js
+```
+
+Після цього відкрийте у браузері `http://localhost:3000` та натисніть кнопку очищення.

--- a/cleaner.js
+++ b/cleaner.js
@@ -172,4 +172,5 @@ function getOptions() {
   return { dryRun, parallel, deepClean, logFile, extraDirs };
 }
 
-module.exports = { pushIfExists, removeDirContents, parseArgs, advancedWindowsClean, getOptions };
+// експортуємо clean для повторного використання у GUI
+module.exports = { pushIfExists, removeDirContents, parseArgs, advancedWindowsClean, getOptions, clean };

--- a/gui.js
+++ b/gui.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { clean } = require('./cleaner');
+
+const indexPath = path.join(__dirname, 'public', 'index.html');
+const indexHtml = fs.readFileSync(indexPath);
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'POST' && req.url === '/clean') {
+    const logs = [];
+    const origLog = console.log;
+    console.log = msg => { logs.push(msg); origLog(msg); };
+    await clean();
+    console.log = origLog;
+    res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end(logs.join('\n'));
+  } else if (req.method === 'GET' && req.url === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(indexHtml);
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const port = 3000;
+server.listen(port, () => {
+  console.log(`GUI доступний на http://localhost:${port}`);
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="UTF-8" />
+  <title>ts-dustbuster GUI</title>
+</head>
+<body>
+  <button id="run">Очистити тимчасові файли</button>
+  <pre id="out"></pre>
+  <script>
+    document.getElementById('run').onclick = async () => {
+      const res = await fetch('/clean', { method: 'POST' });
+      document.getElementById('out').textContent = await res.text();
+    };
+  </script>
+</body>
+</html>

--- a/test.js
+++ b/test.js
@@ -2,11 +2,10 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { pushIfExists, removeDirContents, parseArgs, getOptions } = require('./cleaner');
+const { pushIfExists, removeDirContents, parseArgs, getOptions, clean } = require('./cleaner');
 
 (async () => {
   // Тест pushIfExists
-  // Test for pushIfExists
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'db-test-'));
   const list = [];
   pushIfExists(list, tmp);
@@ -15,7 +14,6 @@ const { pushIfExists, removeDirContents, parseArgs, getOptions } = require('./cl
   assert.strictEqual(list.length, 1, 'Неіснуючий каталог не додається');
 
   // Тест removeDirContents
-  // Test for removeDirContents
   const file = path.join(tmp, 'a.txt');
   fs.writeFileSync(file, 'data');
   const sub = path.join(tmp, 'sub');
@@ -27,11 +25,20 @@ const { pushIfExists, removeDirContents, parseArgs, getOptions } = require('./cl
   fs.rmdirSync(tmp);
 
   // Тест parseArgs
-  // Test for parseArgs
   parseArgs(['--dry-run', '--parallel', '--deep']);
   const opts = getOptions();
   assert.ok(opts.dryRun, 'dry-run має бути увімкнено');
   assert.ok(opts.parallel, 'parallel має бути увімкнено');
   assert.ok(opts.deepClean, 'deep має бути увімкнено');
+
+  // Тест clean у режимі dry-run
+  const tmp2 = fs.mkdtempSync(path.join(os.tmpdir(), 'db-test-'));
+  const tmpFile = path.join(tmp2, 'c.txt');
+  fs.writeFileSync(tmpFile, 'data');
+  parseArgs(['--dir', tmp2]);
+  await clean();
+  assert.ok(fs.existsSync(tmpFile), 'Файл не повинен бути видалений у dry-run');
+  fs.rmSync(tmp2, { recursive: true, force: true });
+
   console.log('Усі тести пройшли');
 })();


### PR DESCRIPTION
## Підсумок
- експортовано `clean` для використання поза CLI
- додано `gui.js` та HTML-сторінку з кнопкою очищення
- описано графічний режим у README
- розширено юніт-тести, що перевіряють роботу `clean` у `dry-run`

## Тестування
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_68908a3a403c832eb88bb20c1a39b514