### PR TITLE
Розширено можливості очищення та додано статистику

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ In both cases the Node.js script `cleaner.js` is executed. It removes contents o
 Починаючи з версії 1.1 скрипт під Linux також очищає каталоги `/var/tmp`, `/var/cache/apt/archives` та `~/.cache` при їх наявності.
 Since version 1.1 the Linux script also cleans `/var/tmp`, `/var/cache/apt/archives` and `~/.cache` if they exist.
 
+У поточній версії додатково перевіряються типові кеші браузерів (Chrome, Edge) та менеджерів пакетів (npm, yarn, pip) на Windows, macOS і Linux — вони очищаються лише за наявності.
+In the current version the tool also targets common caches of browsers (Chrome, Edge) and package managers (npm, yarn, pip) on Windows, macOS and Linux — they are cleaned only when present.
+
 Скрипти автоматично перевіряють наявність Node.js і за потреби встановлюють його. Під Windows додатково очищаються системні каталоги `Prefetch`, `SoftwareDistribution\Download` та `System32\LogFiles`. Під macOS для встановлення використовується Homebrew, якщо він наявний.
 The scripts automatically check for Node.js and install it if needed. On Windows the system folders `Prefetch`, `SoftwareDistribution\Download` and `System32\LogFiles` are cleaned as well. On macOS installation is done via Homebrew when available.
 
@@ -56,6 +59,18 @@ The `cleaner.js` script supports several command-line options:
 - `--config <file>` — JSON file with a `dirs` array of paths.
 - `--log <файл>` — зберігати інформацію про виконання у вказаний файл.
 - `--log <file>` — store execution information in the specified file.
+- `--summary` — наприкінці показати підсумок із кількістю видалених файлів/тек та звільненим місцем.
+- `--summary` — print a summary with the number of removed files/folders and reclaimed space.
+- `--max-age <тривалість>` — видаляти лише елементи, старші за задану тривалість (наприклад, `12h`, `30m`, `5d`; без суфікса — години).
+- `--max-age <duration>` — delete only items older than the given duration (for example `12h`, `30m`, `5d`; default unit is hours when no suffix is provided).
+- `--exclude <шлях>` — ігнорувати вказаний шлях та його вміст під час очищення.
+- `--exclude <path>` — skip the specified path (and its contents) during cleanup.
+
+Поле `--config` тепер може містити не лише список директорій, а й опції `exclude`, `maxAge`, `summary`, `parallel`, `dryRun`, `deep`, `logFile`. Відносні шляхи всередині конфігурації інтерпретуються відносно каталогу цього файлу.
+The `--config` option can now include not only `dirs`, but also `exclude`, `maxAge`, `summary`, `parallel`, `dryRun`, `deep`, `logFile`. Relative paths in the configuration are resolved against the file location.
+
+Під час очищення збирається статистика: кількість видалених файлів, тек, пропущених елементів та звільнений простір. За прапорцем `--summary` ці дані виводяться наприкінці роботи.
+During cleanup the tool gathers statistics: number of removed files, folders, skipped entries and reclaimed space. With the `--summary` flag this information is printed at the end of execution.
 
 ### Графічний режим
 

--- a/cleaner.js
+++ b/cleaner.js
@@ -15,6 +15,9 @@ let parallel = false;
 let deepClean = false;
 let logFile = null;
 const extraDirs = [];
+let summary = false;
+let maxAgeMs = null;
+const exclusions = [];
 // additional directories to clean
 
 function log(msg) {
@@ -24,9 +27,151 @@ function log(msg) {
   }
 }
 
+function normalizePath(target) {
+  return path.resolve(target);
+}
+
+function isWithin(parent, child) {
+  const rel = path.relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+function isExcluded(target) {
+  if (!exclusions.length) {
+    return false;
+  }
+  const resolved = normalizePath(target);
+  return exclusions.some(ex => isWithin(ex, resolved));
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 Б';
+  }
+  const units = ['Б', 'КБ', 'МБ', 'ГБ', 'ТБ'];
+  let idx = 0;
+  let value = bytes;
+  while (value >= 1024 && idx < units.length - 1) {
+    value /= 1024;
+    idx++;
+  }
+  return `${value.toFixed(value >= 10 || idx === 0 ? 0 : 1)} ${units[idx]}`;
+}
+
+function createMetrics() {
+  return { files: 0, dirs: 0, bytes: 0, skipped: 0, errors: 0 };
+}
+
+function mergeMetrics(target, addition) {
+  target.files += addition.files;
+  target.dirs += addition.dirs;
+  target.bytes += addition.bytes;
+  target.skipped += addition.skipped;
+  target.errors += addition.errors;
+  return target;
+}
+
+async function inspectPath(fullPath, stat) {
+  let info = { files: 0, dirs: 0, bytes: 0 };
+  const currentStat = stat || await fs.promises.lstat(fullPath);
+  if (currentStat.isDirectory() && !currentStat.isSymbolicLink()) {
+    info.dirs += 1;
+    try {
+      const entries = await fs.promises.readdir(fullPath);
+      for (const entry of entries) {
+        const child = path.join(fullPath, entry);
+        try {
+          const childStat = await fs.promises.lstat(child);
+          const nested = await inspectPath(child, childStat);
+          info.files += nested.files;
+          info.dirs += nested.dirs;
+          info.bytes += nested.bytes;
+        } catch (err) {
+          console.error(`Не вдалося перевірити ${child}:`, err.message);
+        }
+      }
+    } catch (err) {
+      console.error(`Не вдалося прочитати ${fullPath}:`, err.message);
+    }
+  } else {
+    info.files += 1;
+    info.bytes += currentStat.size || 0;
+  }
+  return info;
+}
+
+function parseDuration(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value < 0) {
+      return null;
+    }
+    return value * 60 * 60 * 1000;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const match = trimmed.match(/^(\d+)([smhdw]?)$/i);
+  if (!match) {
+    return null;
+  }
+  const amount = parseInt(match[1], 10);
+  const unit = (match[2] || 'h').toLowerCase();
+  const multipliers = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+    w: 7 * 24 * 60 * 60 * 1000
+  };
+  const multiplier = multipliers[unit];
+  if (!multiplier) {
+    return null;
+  }
+  return amount * multiplier;
+}
+
+function setMaxAge(value) {
+  const parsed = parseDuration(value);
+  if (parsed === null || Number.isNaN(parsed)) {
+    console.error('Невірне значення для --max-age. Приклад: 12h або 30m.');
+    return false;
+  }
+  maxAgeMs = parsed;
+  return true;
+}
+
+function addExtraDir(dir, baseDir = process.cwd()) {
+  const resolved = normalizePath(path.isAbsolute(dir) ? dir : path.join(baseDir, dir));
+  if (!extraDirs.includes(resolved)) {
+    extraDirs.push(resolved);
+  }
+}
+
+function addExclusion(dir, baseDir = process.cwd()) {
+  const resolved = normalizePath(path.isAbsolute(dir) ? dir : path.join(baseDir, dir));
+  if (!exclusions.includes(resolved)) {
+    exclusions.push(resolved);
+  }
+}
+
+function logSummary(total) {
+  log(`Підсумок: файлів ${total.files}, тек ${total.dirs}, пропущено ${total.skipped}, помилок ${total.errors}, звільнено ${formatBytes(total.bytes)}.`);
+  if (dryRun) {
+    log('Режим dry-run: показані значення відображають потенційно звільнений простір.');
+  }
+}
+
 function pushIfExists(list, dir) {
-  if (fs.existsSync(dir)) {
-    list.push(dir);
+  const resolved = normalizePath(dir);
+  if (fs.existsSync(resolved)) {
+    list.push(resolved);
   }
 }
 
@@ -83,13 +228,44 @@ function parseArgs(args = process.argv.slice(2)) {
     } else if (a === '--log' && args[i + 1]) {
       logFile = args[++i];
     } else if (a === '--dir' && args[i + 1]) {
-      extraDirs.push(args[++i]);
+      addExtraDir(args[++i]);
+    } else if (a === '--exclude' && args[i + 1]) {
+      addExclusion(args[++i]);
+    } else if (a === '--summary') {
+      summary = true;
+    } else if (a === '--max-age' && args[i + 1]) {
+      if (!setMaxAge(args[++i])) {
+        // повідомлення вже виведено всередині setMaxAge
+      }
     } else if (a === '--config' && args[i + 1]) {
       const cfgPath = args[++i];
       try {
         const data = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
         if (Array.isArray(data.dirs)) {
-          extraDirs.push(...data.dirs);
+          data.dirs.forEach(dir => addExtraDir(dir, path.dirname(cfgPath)));
+        }
+        if (Array.isArray(data.exclude)) {
+          data.exclude.forEach(dir => addExclusion(dir, path.dirname(cfgPath)));
+        }
+        if (data.maxAge !== undefined) {
+          setMaxAge(data.maxAge);
+        }
+        if (typeof data.summary === 'boolean') {
+          summary = data.summary;
+        }
+        if (typeof data.parallel === 'boolean') {
+          parallel = data.parallel;
+        }
+        if (typeof data.dryRun === 'boolean') {
+          dryRun = data.dryRun;
+        }
+        if (typeof data.deep === 'boolean') {
+          deepClean = data.deep;
+        }
+        if (typeof data.logFile === 'string') {
+          logFile = path.isAbsolute(data.logFile)
+            ? data.logFile
+            : path.join(path.dirname(cfgPath), data.logFile);
         }
       } catch (err) {
         console.error(`Не вдалося прочитати конфіг ${cfgPath}:`, err.message);
@@ -98,61 +274,142 @@ function parseArgs(args = process.argv.slice(2)) {
   }
 }
 
-async function removeDirContents(dir) {
+async function removeDirContents(dir, metrics = createMetrics()) {
   try {
     const entries = await fs.promises.readdir(dir);
     for (const entry of entries) {
       const fullPath = path.join(dir, entry);
-      if (dryRun) {
-        log(`[dry-run] Видалив би: ${fullPath}`);
-      } else {
-        await fs.promises.rm(fullPath, { recursive: true, force: true });
+      if (isExcluded(fullPath)) {
+        log(`[skip] У переліку виключень: ${fullPath}`);
+        metrics.skipped += 1;
+        continue;
       }
+      let stat;
+      try {
+        stat = await fs.promises.lstat(fullPath);
+      } catch (err) {
+        console.error(`Не вдалося отримати інформацію про ${fullPath}:`, err.message);
+        metrics.errors += 1;
+        continue;
+      }
+      if (maxAgeMs !== null) {
+        const age = Date.now() - stat.mtimeMs;
+        if (age < maxAgeMs) {
+          log(`[skip] Надто свіжий елемент: ${fullPath}`);
+          metrics.skipped += 1;
+          continue;
+        }
+      }
+      let info;
+      try {
+        info = await inspectPath(fullPath, stat);
+      } catch (err) {
+        console.error(`Не вдалося оцінити ${fullPath}:`, err.message);
+        metrics.errors += 1;
+        continue;
+      }
+      if (dryRun) {
+        log(`[dry-run] Видалив би: ${fullPath} (${formatBytes(info.bytes)})`);
+      } else {
+        try {
+          await fs.promises.rm(fullPath, { recursive: true, force: true });
+          log(`Видалено: ${fullPath}`);
+        } catch (err) {
+          console.error(`Не вдалося видалити ${fullPath}:`, err.message);
+          metrics.errors += 1;
+          continue;
+        }
+      }
+      metrics.files += info.files;
+      metrics.dirs += info.dirs;
+      metrics.bytes += info.bytes;
     }
     log(dryRun ? `[dry-run] Завершив ${dir}` : `Очистив: ${dir}`);
   } catch (err) {
     console.error(`Не вдалося очистити ${dir}:`, err.message);
+    metrics.errors += 1;
   }
+  return metrics;
 }
 
-async function clean() {
+async function clean({ targets: targetOverride } = {}) {
   const targets = [];
-  pushIfExists(targets, os.tmpdir());
-  if (process.platform === 'win32') {
-    const winDir = process.env.WINDIR || 'C:/Windows';
-    pushIfExists(targets, path.join(winDir, 'Temp'));
-    pushIfExists(targets, path.join(winDir, 'Prefetch'));
-    pushIfExists(targets, path.join(winDir, 'SoftwareDistribution', 'Download'));
-    pushIfExists(targets, path.join(winDir, 'System32', 'LogFiles'));
-    if (process.env.SystemDrive) {
-      pushIfExists(targets, path.join(process.env.SystemDrive, 'Temp'));
-    }
-    const recycle = path.join(process.env.SystemDrive || 'C:', '$Recycle.Bin');
-    pushIfExists(targets, recycle);
-    if (process.env.LOCALAPPDATA) {
-      pushIfExists(targets, path.join(process.env.LOCALAPPDATA, 'Microsoft', 'Windows', 'INetCache'));
-      pushIfExists(targets, path.join(process.env.LOCALAPPDATA, 'Google', 'Chrome', 'User Data', 'Default', 'Cache'));
-    }
+  if (Array.isArray(targetOverride) && targetOverride.length > 0) {
+    targetOverride.forEach(dir => pushIfExists(targets, dir));
   } else {
-    pushIfExists(targets, '/var/tmp');
-    pushIfExists(targets, '/var/cache/apt/archives');
-    pushIfExists(targets, '/var/cache/apt/archives/partial');
-    pushIfExists(targets, path.join(os.homedir(), '.cache'));
+    pushIfExists(targets, os.tmpdir());
+    if (process.platform === 'win32') {
+      const winDir = process.env.WINDIR || 'C:/Windows';
+      pushIfExists(targets, path.join(winDir, 'Temp'));
+      pushIfExists(targets, path.join(winDir, 'Prefetch'));
+      pushIfExists(targets, path.join(winDir, 'SoftwareDistribution', 'Download'));
+      pushIfExists(targets, path.join(winDir, 'System32', 'LogFiles'));
+      if (process.env.SystemDrive) {
+        pushIfExists(targets, path.join(process.env.SystemDrive, 'Temp'));
+      }
+      const recycle = path.join(process.env.SystemDrive || 'C:', '$Recycle.Bin');
+      pushIfExists(targets, recycle);
+      if (process.env.LOCALAPPDATA) {
+        pushIfExists(targets, path.join(process.env.LOCALAPPDATA, 'Microsoft', 'Windows', 'INetCache'));
+        pushIfExists(targets, path.join(process.env.LOCALAPPDATA, 'Google', 'Chrome', 'User Data', 'Default', 'Cache'));
+        pushIfExists(targets, path.join(process.env.LOCALAPPDATA, 'Microsoft', 'Edge', 'User Data', 'Default', 'Cache'));
+        pushIfExists(targets, path.join(process.env.LOCALAPPDATA, 'CrashDumps'));
+      }
+      if (process.env.APPDATA) {
+        pushIfExists(targets, path.join(process.env.APPDATA, 'npm-cache'));
+      }
+    } else if (process.platform === 'darwin') {
+      pushIfExists(targets, '/var/tmp');
+      pushIfExists(targets, path.join(os.homedir(), 'Library', 'Caches'));
+      pushIfExists(targets, path.join(os.homedir(), 'Library', 'Logs'));
+      pushIfExists(targets, path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome', 'Default', 'Cache'));
+      pushIfExists(targets, path.join(os.homedir(), 'Library', 'Application Support', 'Code', 'Cache'));
+      pushIfExists(targets, path.join(os.homedir(), 'Library', 'Application Support', 'Microsoft Edge', 'Default', 'Cache'));
+    } else {
+      pushIfExists(targets, '/var/tmp');
+      pushIfExists(targets, '/var/cache/apt/archives');
+      pushIfExists(targets, '/var/cache/apt/archives/partial');
+      pushIfExists(targets, path.join(os.homedir(), '.cache'));
+      pushIfExists(targets, path.join(os.homedir(), '.npm'));
+      pushIfExists(targets, path.join(os.homedir(), '.cache', 'npm'));
+      pushIfExists(targets, path.join(os.homedir(), '.cache', 'yarn'));
+      pushIfExists(targets, path.join(os.homedir(), '.cache', 'pip'));
+      pushIfExists(targets, path.join(os.homedir(), '.cache', 'google-chrome'));
+      pushIfExists(targets, path.join(os.homedir(), '.cache', 'chromium'));
+      pushIfExists(targets, path.join(os.homedir(), '.cache', 'Code', 'Cache'));
+    }
+    extraDirs.forEach(d => pushIfExists(targets, d));
   }
-  extraDirs.forEach(d => pushIfExists(targets, d));
 
-  const tasks = targets.map(dir => removeDirContents(dir));
-  if (parallel) {
-    await Promise.all(tasks);
-  } else {
-    for (const t of tasks) {
-      await t;
+  const filteredTargets = targets.filter(dir => {
+    if (isExcluded(dir)) {
+      log(`[skip] Каталог пропущено за виключенням: ${dir}`);
+      return false;
     }
+    return true;
+  });
+
+  const allMetrics = [];
+  const tasks = filteredTargets.map(dir => removeDirContents(dir, createMetrics()));
+  if (parallel) {
+    allMetrics.push(...await Promise.all(tasks));
+  } else {
+    for (const task of tasks) {
+      allMetrics.push(await task);
+    }
+  }
+
+  const total = allMetrics.reduce((acc, item) => mergeMetrics(acc, item), createMetrics());
+
+  if (summary) {
+    logSummary(total);
   }
 
   if (deepClean && process.platform === 'win32') {
     advancedWindowsClean();
   }
+
+  return total;
 }
 
 parseArgs();
@@ -169,8 +426,28 @@ if (require.main === module) {
 }
 
 function getOptions() {
-  return { dryRun, parallel, deepClean, logFile, extraDirs };
+  return {
+    dryRun,
+    parallel,
+    deepClean,
+    logFile,
+    extraDirs: [...extraDirs],
+    summary,
+    maxAgeMs,
+    exclusions: [...exclusions]
+  };
+}
+
+function resetOptions() {
+  dryRun = false;
+  parallel = false;
+  deepClean = false;
+  logFile = null;
+  summary = false;
+  maxAgeMs = null;
+  extraDirs.length = 0;
+  exclusions.length = 0;
 }
 
 // експортуємо clean для повторного використання у GUI
-module.exports = { pushIfExists, removeDirContents, parseArgs, advancedWindowsClean, getOptions, clean };
+module.exports = { pushIfExists, removeDirContents, parseArgs, advancedWindowsClean, getOptions, clean, resetOptions };

--- a/test.js
+++ b/test.js
@@ -2,10 +2,11 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { pushIfExists, removeDirContents, parseArgs, getOptions, clean } = require('./cleaner');
+const { pushIfExists, removeDirContents, parseArgs, getOptions, clean, resetOptions } = require('./cleaner');
 
 (async () => {
   // Тест pushIfExists
+  resetOptions();
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'db-test-'));
   const list = [];
   pushIfExists(list, tmp);
@@ -14,31 +15,72 @@ const { pushIfExists, removeDirContents, parseArgs, getOptions, clean } = requir
   assert.strictEqual(list.length, 1, 'Неіснуючий каталог не додається');
 
   // Тест removeDirContents
+  resetOptions();
   const file = path.join(tmp, 'a.txt');
   fs.writeFileSync(file, 'data');
   const sub = path.join(tmp, 'sub');
   fs.mkdirSync(sub);
   fs.writeFileSync(path.join(sub, 'b.txt'), 'data');
-  await removeDirContents(tmp);
+  const metricsAfterRemove = await removeDirContents(tmp);
   const entries = fs.readdirSync(tmp);
   assert.strictEqual(entries.length, 0, 'Каталог має бути порожнім');
+  assert.strictEqual(metricsAfterRemove.files, 2, 'Має бути видалено два файли (включно з вкладеними)');
+  assert.strictEqual(metricsAfterRemove.dirs, 1, 'Має бути видалено одну піддиректорію');
   fs.rmdirSync(tmp);
 
   // Тест parseArgs
-  parseArgs(['--dry-run', '--parallel', '--deep']);
+  resetOptions();
+  const excludeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'db-exclude-'));
+  parseArgs(['--dry-run', '--parallel', '--deep', '--summary', '--max-age', '2d', '--exclude', excludeDir, '--log', 'out.log']);
   const opts = getOptions();
   assert.ok(opts.dryRun, 'dry-run має бути увімкнено');
   assert.ok(opts.parallel, 'parallel має бути увімкнено');
   assert.ok(opts.deepClean, 'deep має бути увімкнено');
+  assert.ok(opts.summary, 'summary має бути увімкнено');
+  assert.strictEqual(opts.maxAgeMs, 2 * 24 * 60 * 60 * 1000, 'maxAge має відповідати 2 дням');
+  assert.ok(opts.exclusions.includes(path.resolve(excludeDir)), 'Шлях має бути у переліку виключень');
+  assert.strictEqual(opts.logFile, 'out.log', 'Шлях до лог-файлу зберігається як передано');
+  resetOptions();
+  fs.rmSync(excludeDir, { recursive: true, force: true });
 
   // Тест clean у режимі dry-run
+  resetOptions();
   const tmp2 = fs.mkdtempSync(path.join(os.tmpdir(), 'db-test-'));
   const tmpFile = path.join(tmp2, 'c.txt');
   fs.writeFileSync(tmpFile, 'data');
-  parseArgs(['--dir', tmp2]);
-  await clean();
+  const nestedDir = path.join(tmp2, 'nested');
+  fs.mkdirSync(nestedDir);
+  const nestedFile = path.join(nestedDir, 'd.txt');
+  fs.writeFileSync(nestedFile, 'd');
+  parseArgs(['--dry-run', '--summary']);
+  const dryMetrics = await clean({ targets: [tmp2] });
   assert.ok(fs.existsSync(tmpFile), 'Файл не повинен бути видалений у dry-run');
+  assert.ok(fs.existsSync(nestedFile), 'Вкладений файл не повинен бути видалений у dry-run');
+  assert.strictEqual(dryMetrics.files, 2, 'Повинно враховуватися два файли у dry-run');
+  assert.strictEqual(dryMetrics.dirs, 1, 'Повинна враховуватися одна директорія у dry-run');
   fs.rmSync(tmp2, { recursive: true, force: true });
+
+  // Тест max-age та exclude
+  resetOptions();
+  const tmp3 = fs.mkdtempSync(path.join(os.tmpdir(), 'db-test-'));
+  const oldFile = path.join(tmp3, 'old.txt');
+  fs.writeFileSync(oldFile, 'старі дані');
+  const threeDaysAgoSeconds = (Date.now() - 3 * 24 * 60 * 60 * 1000) / 1000;
+  fs.utimesSync(oldFile, threeDaysAgoSeconds, threeDaysAgoSeconds);
+  const newFile = path.join(tmp3, 'new.txt');
+  fs.writeFileSync(newFile, 'свіжі дані');
+  const protectedDir = path.join(tmp3, 'keep');
+  fs.mkdirSync(protectedDir);
+  const protectedFile = path.join(protectedDir, 'secret.txt');
+  fs.writeFileSync(protectedFile, 'не чіпати');
+  parseArgs(['--max-age', '2d', '--exclude', protectedDir]);
+  const resultMetrics = await clean({ targets: [tmp3] });
+  assert.ok(!fs.existsSync(oldFile), 'Старий файл має бути видалений');
+  assert.ok(fs.existsSync(newFile), 'Новий файл має бути збережений через max-age');
+  assert.ok(fs.existsSync(protectedFile), 'Файл у виключеній директорії має залишитися');
+  assert.ok(resultMetrics.files >= 1, 'Повинен бути щонайменше один видалений файл');
+  assert.ok(resultMetrics.skipped >= 2, 'Повинні бути пропуски через max-age та exclude');
+  fs.rmSync(tmp3, { recursive: true, force: true });
 
   console.log('Усі тести пройшли');
 })();


### PR DESCRIPTION
### Зміни
- додано підтримку прапорців `--summary`, `--max-age`, `--exclude`, розширено парсер конфігурацій та запроваджено підрахунок статистики очищення
- розширено набір каталогів за замовчуванням для Windows, macOS і Linux та додано можливість передавати власний список під час повторного використання `clean`
- оновлено README та юніт-тести для нової поведінки й забезпечено скидання глобальних опцій між тестами

### Тестування
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d059c95968832eb184519e0dac4688