### PR TITLE
Додано підтримку пресетів конфігурацій

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ The `cleaner.js` script supports several command-line options:
 - `--concurrency <number>` — limit the amount of concurrent cleanup operations (values > 1 enable parallel mode automatically).
 - `--dir <шлях>` — додати власну директорію до списку для очистки (можна вказувати кілька разів).
 - `--dir <path>` — add a custom directory to the cleanup list (can be used multiple times).
-- `--config <файл>` — JSON-файл з полем `dirs`, що містить масив шляхів.
+- `--config <файл>` — файл налаштувань у форматі JSON або YAML з описом директорій, виключень та додаткових опцій.
+- `--preset <назва|шлях>` — застосувати попередньо підготовлений пресет (шукається у поточному каталозі, `./presets` або за повним шляхом).
 - `--config <file>` — JSON file with a `dirs` array of paths.
 - `--log <файл>` — зберігати інформацію про виконання у вказаний файл.
 - `--log <file>` — store execution information in the specified file.
@@ -68,7 +69,15 @@ The `cleaner.js` script supports several command-line options:
 - `--exclude <шлях>` — ігнорувати вказаний шлях та його вміст під час очищення.
 - `--exclude <path>` — skip the specified path (and its contents) during cleanup.
 
-Поле `--config` тепер може містити не лише список директорій, а й опції `exclude`, `maxAge`, `summary`, `parallel`, `dryRun`, `deep`, `logFile`, `concurrency`. Відносні шляхи всередині конфігурації інтерпретуються відносно каталогу цього файлу.
+Поле `--config` тепер може містити не лише список директорій, а й опції `exclude`, `maxAge`, `summary`, `parallel`, `dryRun`, `deep`, `logFile`, `concurrency`. Відносні шляхи всередині конфігурації інтерпретуються відносно каталогу цього файлу. Конфігурації можуть включати інші пресети через поле `presets`, яке приймає перелік назв або шляхів до додаткових JSON/YAML файлів. Будь-які помилки в структурі або значеннях конфігурацій відображаються як дружні повідомлення, а зміни не застосовуються до виправлення помилки.
+
+Прапорець `--preset` дозволяє комбінувати кілька пресетів безпосередньо з CLI, наприклад:
+
+```bash
+dustbuster --preset базовий --preset prod-extra
+```
+
+Послідовність пресетів має значення: останні перевизначають значення попередніх, а списки директорій та виключень об'єднуються.
 The `--config` option can now include not only `dirs`, but also `exclude`, `maxAge`, `summary`, `parallel`, `dryRun`, `deep`, `logFile`, `concurrency`. Relative paths in the configuration are resolved against the file location.
 
 Під час очищення збирається статистика: кількість видалених файлів, тек, пропущених елементів та звільнений простір. За прапорцем `--summary` ці дані виводяться наприкінці роботи.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "ts-dustbuster",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ts-dustbuster",
+      "version": "1.0.0",
+      "dependencies": {
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "dustbuster": "cleaner.js"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "ts-dustbuster",
   "version": "1.0.0",
-  "bin": { "dustbuster": "./cleaner.js" },
+  "bin": {
+    "dustbuster": "./cleaner.js"
+  },
   "scripts": {
     "start": "node cleaner.js",
     "test": "node test.js"
   },
-  "dependencies": {},
-  "devDependencies": {}
+  "dependencies": {
+    "yaml": "^2.8.1"
+  }
 }


### PR DESCRIPTION
## Summary
- додано підтримку читання конфігураційних пресетів у форматах JSON та YAML з комбінуванням і перевіркою даних
- розширено CLI новими перевірками аргументів та прапорцем `--preset`, забезпечено коректний вихід у разі помилок конфігурації
- оновлено README та юніт-тести для покриття нового функціоналу пресетів і валідації

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d99ccc4c04832ea775f5f9ac57937a