### PR TITLE
Додати пакетне завантаження конфігурацій із каталогу

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ The `cleaner.js` script supports several command-line options:
 - `--dir <шлях>` — додати власну директорію до списку для очистки (можна вказувати кілька разів).
 - `--dir <path>` — add a custom directory to the cleanup list (can be used multiple times).
 - `--config <файл>` — файл налаштувань у форматі JSON або YAML з описом директорій, виключень та додаткових опцій.
+- `--config <каталог>` — застосувати всі файли конфігурацій (`*.json`, `*.yaml`, `*.yml`) з каталогу у алфавітному порядку як один пакет.
 - `--preset <назва|шлях>` — застосувати попередньо підготовлений пресет (шукається у поточному каталозі, `./presets` або за повним шляхом).
 - `--config <file>` — JSON file with a `dirs` array of paths.
+- `--config <directory>` — apply every JSON/YAML configuration inside the directory in alphabetical order as a single batch.
 - `--log <файл>` — зберігати інформацію про виконання у вказаний файл.
 - `--log <file>` — store execution information in the specified file.
 - `--summary` — наприкінці показати підсумок із кількістю видалених файлів/тек та звільненим місцем.


### PR DESCRIPTION
## Summary
- додано можливість передавати каталог у `--config`, щоб застосовувати всі JSON/YAML-файли як один пакет
- посилено перевірки шляху та повідомлення про помилки для пакетних конфігурацій
- оновлено документацію та юніт-тести для покриття пакетних сценаріїв

## Testing
- node test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9a265ae7c832eb72758b0305ee89f